### PR TITLE
docs(*): add more examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,28 @@ Note that for ES5 `Class` syntax and TypeScript you need a polyfill for the [Ref
 
 ```ts
 import 'reflect-metadata';
-import { ReflectiveInjector, Injectable } from 'injection-js';
+import { ReflectiveInjector, Injectable, Injector } from 'injection-js';
 
 class Http {}
 
 @Injectable()
 class Service {
   constructor(private http: Http) {}
+}
+
+@Injectable()
+class Service2 {
+  constructor(private injector: Injector) {}
+  
+  getService(): void {
+    console.log(this.injector.get(Service) instanceof Service);
+  }
+  
+  createChildInjector(): void {
+    const childInjector = ReflectiveInjector.resolveAndCreate([
+      Service
+    ], this.injector);
+  }
 }
 
 const injector = ReflectiveInjector.resolveAndCreate([


### PR DESCRIPTION
Add more examples, including:

- Injecting `Injector`
- Manually getting `Injectable` via `Injector` instance
- Creating child container from parent `Injector`