### PR TITLE
feat: export Type, TypeDecorator and makeDecorator

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,5 +22,5 @@ export {Provider, TypeProvider, ValueProvider, ClassProvider, ExistingProvider, 
 export {ResolvedReflectiveFactory, ResolvedReflectiveProvider} from './reflective_provider';
 export {ReflectiveKey} from './reflective_key';
 export {InjectionToken, OpaqueToken} from './injection_token';
-export {Class} from './util/decorators';
-
+export {Class, TypeDecorator, makeDecorator} from './util/decorators';
+export {Type} from './facade/type';


### PR DESCRIPTION
Hi @mgechev,

We use `injection-js` for our Node js framework and we need to access:
- `Type`: /facade/type
- `TypeDecorator`: /util/decorators
- `makeDecorator`: /util/decorators
[https://github.com/hapinessjs/hapiness/blob/master/src/core/decorators.ts](https://github.com/hapinessjs/hapiness/blob/master/src/core/decorators.ts)
The bundle does not allow to access them.