### PR TITLE
feat: add resolveDependencies() utility

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,4 +23,5 @@ export { ResolvedReflectiveFactory, ResolvedReflectiveProvider } from './reflect
 export { ReflectiveKey } from './reflective_key';
 export { InjectionToken, OpaqueToken } from './injection_token';
 export { Class, TypeDecorator, makeDecorator } from './util/decorators';
+export { resolveDependencies } from './util/resolve_dependencies';
 export { Type, isType } from './facade/type';

--- a/lib/util/resolve_dependencies.ts
+++ b/lib/util/resolve_dependencies.ts
@@ -1,0 +1,71 @@
+import { ReflectiveInjector } from '../reflective_injector';
+import { ResolvedReflectiveProvider, ResolvedReflectiveFactory, ReflectiveDependency } from '../reflective_provider';
+
+type Constructor = new (...args: any[]) => any;
+
+/**
+ * This utility function receives a spread of injectable classes
+ * and returns an array of all their dependencies. Also resolves
+ * optional dependencies.
+ *
+ * ### Important:
+ *
+ * Dynamically resolving dependencies using this function
+ * will not play nice with static analysis tools, including tree-shaking.
+ * From a static analysis perspective, any dependencies which are only resolved
+ * using this function will look as though they are not used (and will be
+ * removed by tree-shaking). This *severely* limits the usefulness of this function.
+ *
+ * ### Example:
+ *
+ * ```typescript
+ * class HTTP {}
+ * class Database {}
+ *
+ * // commenting out the decorator because the `@` symbol is spoiling
+ * // jsDoc rendering in vscode
+ * // @Injectable()
+ * class PersonService {
+ *   constructor(
+ *     private http: HTTP,
+ *     private database: Database,
+ *   ) {}
+ * }
+ *
+ * // @Injectable()
+ * class OrganizationService {
+ *   constructor(
+ *     private http: HTTP,
+ *     private personService: PersonService,
+ *   ) {}
+ * }
+ *
+ * const injector = ReflectiveInjector.resolveAndCreate(
+ *   resolveDependencies(OrganizationService)
+ * );
+ *
+ * const organizationService = injector.get(OrganizationService);
+ * ```
+ */
+export function resolveDependencies(...inputs: Constructor[]) {
+  const deps = new Set<Constructor>();
+
+  function resolver(klass: Constructor) {
+    if (deps.has(klass)) return;
+
+    deps.add(klass);
+
+    // resolve all dependencies of the provided class and run the `resolver()` function
+    // on their constructor functions.
+    ReflectiveInjector.resolve([klass])
+      .reduce((a, x: ResolvedReflectiveProvider) => a.concat(x.resolvedFactories), [] as ResolvedReflectiveFactory[])
+      .reduce((a, r: ResolvedReflectiveFactory) => a.concat(r.dependencies), [] as ReflectiveDependency[])
+      .forEach(d => resolver(d.key.token as Constructor));
+  }
+
+  for (const input of inputs) {
+    resolver(input);
+  }
+
+  return Array.from(deps);
+}

--- a/test/resolve_dependencies_spec.ts
+++ b/test/resolve_dependencies_spec.ts
@@ -1,0 +1,88 @@
+import { resolveDependencies } from '../lib/util/resolve_dependencies';
+import { Injectable, Optional, Inject, Provider } from '../lib';
+import { ReflectiveInjector } from '../lib/reflective_injector';
+
+class Engine {}
+
+class DashboardSoftware {}
+
+@Injectable()
+class Dashboard {
+  constructor(software: DashboardSoftware) {}
+}
+
+class TurboEngine extends Engine {}
+
+@Injectable()
+class CarWithDashboard {
+  engine: Engine;
+  dashboard: Dashboard;
+  constructor(engine: Engine, dashboard: Dashboard) {
+    this.engine = engine;
+    this.dashboard = dashboard;
+  }
+}
+
+@Injectable()
+class CarWithOptionalEngine {
+  constructor(@Optional() public engine: Engine) {}
+}
+
+@Injectable()
+class CarWithInject {
+  constructor(@Inject(TurboEngine) public engine: Engine) {}
+}
+
+function createInjector(providers: Provider[]): ReflectiveInjector {
+  return ReflectiveInjector.resolveAndCreate(providers);
+}
+
+describe('resolveDependencies', function() {
+  let deps: Array<new (...args: any[]) => any>;
+  let injector: ReflectiveInjector | null;
+
+  beforeEach(function() {
+    deps = [];
+    injector = null;
+  });
+
+  it('should resolve direct dependencies', function() {
+    deps = resolveDependencies(Dashboard);
+
+    expect(deps).toEqual([Dashboard, DashboardSoftware]);
+
+    injector = createInjector(deps);
+
+    expect(injector.get(Dashboard) instanceof Dashboard).toBe(true);
+  });
+
+  it('should resolve dependencies of dependencies', function() {
+    deps = resolveDependencies(CarWithDashboard);
+
+    expect(deps).toEqual([CarWithDashboard, Engine, Dashboard, DashboardSoftware]);
+
+    injector = createInjector(deps);
+
+    expect(injector.get(CarWithDashboard) instanceof CarWithDashboard).toBe(true);
+  });
+
+  it('should resolve optional dependencies', function() {
+    deps = resolveDependencies(CarWithOptionalEngine);
+
+    expect(deps).toEqual([CarWithOptionalEngine, Engine]);
+
+    injector = createInjector(deps);
+
+    expect(injector.get(CarWithOptionalEngine) instanceof CarWithOptionalEngine).toBe(true);
+  });
+
+  it('should resolve re-provided dependencies', function() {
+    deps = resolveDependencies(CarWithInject);
+
+    expect(deps).toEqual([CarWithInject, TurboEngine]);
+
+    injector = createInjector(deps);
+
+    expect(injector.get(CarWithInject) instanceof CarWithInject).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR adds a `resolveDependencies()` utility function which receives a spread of injectable classes and recursively resolves all of their dependencies, returning them in an array.

 Usage like

```typescript
class HTTP {}
class Database {}

@Injectable()
class PersonService {
  constructor(
    private http: HTTP,
    private database: Database,
  ) {}
}

@Injectable()
class OrganizationService {
  constructor(
    private http: HTTP,
    private personService: PersonService,
  ) {}
}

const injector = ReflectiveInjector.resolveAndCreate(
  resolveDependencies(OrganizationService)
);

const organizationService = injector.get(OrganizationService);
```

A ***MAJOR*** limitation of this function is that it's usage will not play nice with static analysis tools such as tree shaking. I added a big, bold jsDoc comment to the function's description calling out the fact that tree shaking tools will remove any dependency which was only imported using `resolveDependencies()`. Put simply, this utility should not be used in combination with tree shaking or at the least should only be used by someone who knows what they are doing.

Even though the usefulness of this function is severely limited, it has come up in at least two separate issues (#6 and #40) so it seems worth adding.

Big thanks to [a comment](https://github.com/mgechev/injection-js/issues/6#issuecomment-283337944) by @juneil for guiding me on the implementation.

Fixes #40, #6 