### PR TITLE
fix: add tslib as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/mgechev/injection-js.git"
   },
-  "peerDependencies": {
+  "dependencies": {
     "tslib": "^1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
When a consumer is using TS 3.9+, they will not be able to meet this requirement because TS 3.5 requires tslib 2.0.

Similar to angular packages we move tslib to a direct dependency since it’s coupled with the version of typescript used to be this library.

See: https://github.com/ng-packagr/ng-packagr/issues/1679#issuecomment-653682136