### PR TITLE
feat: export makeParamDecorator and makePropDecorator 

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -22,6 +22,6 @@ export { Provider, TypeProvider, ValueProvider, ClassProvider, ExistingProvider,
 export { ResolvedReflectiveFactory, ResolvedReflectiveProvider } from './reflective_provider';
 export { ReflectiveKey } from './reflective_key';
 export { InjectionToken, OpaqueToken } from './injection_token';
-export { Class, TypeDecorator, makeDecorator } from './util/decorators';
+export { Class, TypeDecorator, makeDecorator, makeParamDecorator, makePropDecorator } from './util/decorators';
 export { resolveDependencies } from './util/resolve_dependencies';
 export { Type, isType } from './facade/type';


### PR DESCRIPTION
Hi @mgechev,

I use `injection-js` for my [Node js framework](https://github.com/mildronize/mildjs) and I need to access:

`makeParamDecorator`: /util/decorators
`makePropDecorator`: /util/decorators

Thank you very much.