### PR TITLE
Add the inject() function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -25,3 +25,4 @@ export { InjectionToken, OpaqueToken } from './injection_token';
 export { Class, TypeDecorator, makeDecorator, makeParamDecorator, makePropDecorator } from './util/decorators';
 export { resolveDependencies } from './util/resolve_dependencies';
 export { Type, isType } from './facade/type';
+export { inject } from './injector_compatibility';

--- a/lib/injector_compatibility.ts
+++ b/lib/injector_compatibility.ts
@@ -1,0 +1,36 @@
+import { Type } from "./facade/type";
+import { InjectionToken } from "./injection_token";
+import { Injector } from "./injector";
+
+
+/**
+ * Current injector value used by `inject`.
+ * - `undefined`: it is an error to call `inject`
+ * - Injector instance: Use the injector for resolution.
+ */
+let _currentInjector: Injector | undefined = undefined;
+
+export function getCurrentInjector(): Injector | undefined {
+  return _currentInjector;
+}
+
+
+export function setCurrentInjector(
+  injector: Injector | undefined,
+): Injector | undefined {
+  const former = _currentInjector;
+  _currentInjector = injector;
+  return former;
+}
+
+
+export function inject<T>(token: Type<T> | InjectionToken<T>): T {
+  if (_currentInjector === undefined) {
+    throw new Error(
+      `inject() must be called from an injection context such as a constructor, a factory function, or a field initializer`,
+    );
+  } else {
+    const value = _currentInjector.get(token);
+    return value;
+  }
+}

--- a/test/reflective_injector_spec.ts
+++ b/test/reflective_injector_spec.ts
@@ -19,6 +19,7 @@ import {
   ReflectiveKey,
   Self,
   forwardRef,
+  inject,
 } from '../lib';
 import { ReflectiveInjector_ } from '../lib/reflective_injector';
 import { ResolvedReflectiveProvider_ } from '../lib/reflective_provider';
@@ -39,6 +40,13 @@ class DashboardSoftware {}
 @Injectable()
 class Dashboard {
   constructor(software: DashboardSoftware) {}
+}
+
+class GloveboxManual {}
+
+@Injectable()
+class Glovebox {
+  manual = inject(GloveboxManual);
 }
 
 class TurboEngine extends Engine {}
@@ -350,6 +358,13 @@ describe(`injector`, () => {
   it('should support null values', () => {
     const injector = createInjector([{ provide: 'null', useValue: null }]);
     expect(injector.get('null')).toBe(null);
+  });
+
+  it('should support the inject() function', () => {
+    const injector = createInjector([Glovebox, GloveboxManual]);
+    const glovebox = injector.get(Glovebox);
+    expect(glovebox instanceof Glovebox).toBe(true);
+    expect(glovebox.manual instanceof GloveboxManual).toBe(true);
   });
 });
 


### PR DESCRIPTION
This PR adds the inject function. It can only be used in an injection context, which right now is only activated during injection. I.e. you cannot manually set the injection context to call inject() yourself at the top level. 

Resolves #59