### PR TITLE
feat: add the `Injector.getMany` method

### DIFF
--- a/lib/injector.ts
+++ b/lib/injector.ts
@@ -22,6 +22,9 @@ class _NullInjector implements Injector {
     }
     return notFoundValue;
   }
+  getMany<Tokens extends InjectorGetManyParam<any>[]>(...tokens: Tokens): InjectorGetManySignature<Tokens> {
+    return tokens.map(({ token, notFoundValue }) => this.get(token, notFoundValue)) as InjectorGetManySignature<Tokens>;
+  }
 }
 
 /**
@@ -61,4 +64,33 @@ export abstract class Injector {
    * @suppress {duplicate}
    */
   abstract get(token: any, notFoundValue?: any): any;
+  /**
+   * Retrieves an instance from the injector based on the provided tokens.
+   * @param tokens See {@link InjectorGetManyParam}.
+   * @example
+   * ```ts
+   * const [car, engine, dashboard] = injector.getMany(
+   *   { token: Car },
+   *   { token: Engine },
+   *   { token: Dashboard, notFoundValue: null }
+   * );
+   * ```
+   */
+  abstract getMany<Tokens extends InjectorGetManyParam<any>[]>(...tokens: Tokens): InjectorGetManySignature<Tokens>;
 }
+
+export type InjectorGetManySignature<Tokens extends InjectorGetManyParam<any>[]> = {
+  [K in keyof Tokens]: Tokens[K] extends InjectorGetManyParam<infer U> ? U : never;
+};
+
+export type InjectorGetManyParam<T> = {
+  /** Retrieves an instance from the injector based on the provided token. */
+  token: Type<T> | InjectionToken<T>;
+  /**
+   * If not found:
+   * - Throws {@link NoProviderError} if no `notFoundValue` that is not equal to
+   * Injector.THROW_IF_NOT_FOUND is given
+   * - Returns the `notFoundValue` otherwise
+   */
+  notFoundValue?: T;
+};

--- a/lib/reflective_injector.ts
+++ b/lib/reflective_injector.ts
@@ -7,7 +7,7 @@
  */
 
 import { Type } from './facade/type';
-import { Injector, THROW_IF_NOT_FOUND } from './injector';
+import { Injector, type InjectorGetManyParam, type InjectorGetManySignature, THROW_IF_NOT_FOUND } from './injector';
 import { setCurrentInjector } from './injector_compatibility';
 import { Self, SkipSelf } from './metadata';
 import { Provider } from './provider';
@@ -280,6 +280,8 @@ export abstract class ReflectiveInjector implements Injector {
   abstract instantiateResolved(provider: ResolvedReflectiveProvider): any;
 
   abstract get(token: any, notFoundValue?: any): any;
+
+  abstract getMany<Tokens extends InjectorGetManyParam<any>[]>(...tokens: Tokens): InjectorGetManySignature<Tokens>;
 }
 
 // tslint:disable-next-line:class-name
@@ -313,6 +315,10 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
 
   get(token: any, notFoundValue: any = THROW_IF_NOT_FOUND): any {
     return this._getByKey(ReflectiveKey.get(token), null, notFoundValue);
+  }
+
+  getMany<Tokens extends InjectorGetManyParam<any>[]>(...tokens: Tokens): InjectorGetManySignature<Tokens> {
+    return tokens.map(({ token, notFoundValue }) => this.get(token, notFoundValue)) as InjectorGetManySignature<Tokens>;
   }
 
   get parent(): Injector | null {

--- a/test/injector_spec.ts
+++ b/test/injector_spec.ts
@@ -20,4 +20,14 @@ describe('Injector.NULL', () => {
   it('should return the default value', () => {
     expect(Injector.NULL.get('someToken', 'notFound')).toEqual('notFound');
   });
+
+  it('should correctly return tuple of multiple default values', () => {
+    expect(
+      Injector.NULL.getMany(
+        { token: Object, notFoundValue: 'A' },
+        { token: Object, notFoundValue: 'B' },
+        { token: Object, notFoundValue: 'C' }
+      )
+    ).toEqual(['A', 'B', 'C']);
+  });
 });

--- a/test/reflective_injector_spec.ts
+++ b/test/reflective_injector_spec.ts
@@ -366,6 +366,28 @@ describe(`injector`, () => {
     expect(glovebox instanceof Glovebox).toBe(true);
     expect(glovebox.manual instanceof GloveboxManual).toBe(true);
   });
+
+  it('should correctly get multiple providers', () => {
+    const injector = createInjector([Car, Engine, TurboEngine]);
+    const [car, engine, turboEngine] = injector.getMany({ token: Car }, { token: Engine }, { token: TurboEngine });
+
+    expect(car instanceof Car).toBe(true);
+    expect(engine instanceof Engine).toBe(true);
+    expect(turboEngine instanceof TurboEngine).toBe(true);
+  });
+
+  it('should use the default values with get multiple providers', () => {
+    const injector = createInjector([Engine]);
+    const [car, engine, turboEngine] = injector.getMany(
+      { token: Object, notFoundValue: 'car' },
+      { token: Engine },
+      { token: Object, notFoundValue: null }
+    );
+
+    expect(car).toBe('car');
+    expect(engine instanceof Engine).toBe(true);
+    expect(turboEngine).toBe(null);
+  });
 });
 
 describe('child', () => {


### PR DESCRIPTION
Adds a new `getMany` method to the `Injector` class which can be used to easily retrieve multiple instances based on the provided tokens.

eg:

```ts
const [car, engine, dashboard] = injector.getMany(
  { token: Car },
  { token: Engine },
  { token: Dashboard, notFoundValue: null }
);
 ```

[x] Unit Tests coverage