### PR TITLE
fix: abstract type support for `inject()`

### DIFF
--- a/lib/facade/type.ts
+++ b/lib/facade/type.ts
@@ -11,7 +11,7 @@
  *
  * @description
  *
- * An example of a `Type` is `MyCustomComponent` class, which in JavaScript is be represented by
+ * An example of a `Type` is `MyCustomComponent` class, which in JavaScript is being represented by
  * the `MyCustomComponent` constructor function.
  *
  * @stable
@@ -20,6 +20,16 @@ export const Type = Function;
 
 export function isType(v: any): v is Type<any> {
   return typeof v === 'function';
+}
+
+/**
+ * @description
+ *
+ * Represents an abstract class `T`, if applied to a concrete class it would stop being
+ * instantiable.
+ */
+export interface AbstractType<T> extends Function {
+  prototype: T;
 }
 
 export interface Type<T = object> extends Function {

--- a/lib/injector.ts
+++ b/lib/injector.ts
@@ -7,9 +7,7 @@
  */
 
 import { stringify } from './facade/lang';
-import { Type } from './facade/type';
-
-import { InjectionToken } from './injection_token';
+import { ProviderToken } from './provider-token';
 
 const _THROW_IF_NOT_FOUND = new Object();
 export const THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
@@ -48,16 +46,12 @@ export abstract class Injector {
   static THROW_IF_NOT_FOUND = _THROW_IF_NOT_FOUND;
   static NULL: Injector = new _NullInjector();
 
+  abstract get<T>(token: ProviderToken, notFoundValue?: T): T;
+  abstract get<T>(token: ProviderToken<T>, notFoundValue?: T): T;
+  abstract get<T>(token: ProviderToken, notFoundValue?: T | null): T | null;
+  abstract get<T>(token: ProviderToken<T>, notFoundValue?: T | null): T | null;
   /**
-   * Retrieves an instance from the injector based on the provided token.
-   * If not found:
-   * - Throws {@link NoProviderError} if no `notFoundValue` that is not equal to
-   * Injector.THROW_IF_NOT_FOUND is given
-   * - Returns the `notFoundValue` otherwise
-   */
-  abstract get<T>(token: Type<T> | InjectionToken<T>, notFoundValue?: T): T;
-  /**
-   * @deprecated from v4.0.0 use Type<T> or InjectionToken<T>
+   * @deprecated use {@link ProviderToken} instead
    * @suppress {duplicate}
    */
   abstract get(token: any, notFoundValue?: any): any;

--- a/lib/provider-token.ts
+++ b/lib/provider-token.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import { AbstractType, Type } from './facade/type';
+import { InjectionToken } from './injection_token';
+
+/**
+ * @description
+ *
+ * Token that can be used to retrieve an instance from an injector or through a query.
+ *
+ * @publicApi
+ */
+export type ProviderToken<T = any> = Type<T> | AbstractType<T> | InjectionToken<T> | string;

--- a/lib/reflective_injector.ts
+++ b/lib/reflective_injector.ts
@@ -6,11 +6,11 @@
  * found in the LICENSE file at https://angular.io/license
  */
 
-import { Type } from './facade/type';
 import { Injector, THROW_IF_NOT_FOUND } from './injector';
 import { setCurrentInjector } from './injector_compatibility';
 import { Self, SkipSelf } from './metadata';
 import { Provider } from './provider';
+import { ProviderToken } from './provider-token';
 import { cyclicDependencyError, instantiationError, noProviderError, outOfBoundsError } from './reflective_errors';
 import { ReflectiveKey } from './reflective_key';
 import {
@@ -311,6 +311,8 @@ export class ReflectiveInjector_ implements ReflectiveInjector {
     }
   }
 
+  get<T>(token: ProviderToken<T>, notFoundValue?: T): T;
+  get<T>(token: ProviderToken<any>, notFoundValue?: T): T;
   get(token: any, notFoundValue: any = THROW_IF_NOT_FOUND): any {
     return this._getByKey(ReflectiveKey.get(token), null, notFoundValue);
   }

--- a/test/injector_compatibility_spec.ts
+++ b/test/injector_compatibility_spec.ts
@@ -60,6 +60,51 @@ describe('inject()', () => {
     expect(bar).toBeInstanceOf(Bar);
   });
 
+  it('should allow optional injection', () => {
+    class Foo {}
+
+    const { injector } = setup();
+
+    const foo = runInInjectionContext(injector, () => inject(Foo, { optional: true }));
+
+    expect(foo).toBeNull();
+  });
+
+  it('should support an abstract type as token', () => {
+    abstract class AbstractFoo {}
+    class Foo extends AbstractFoo {
+      readonly bar = inject(Bar);
+    }
+
+    const { injector } = setup([
+      {
+        provide: AbstractFoo,
+        useClass: Foo,
+      },
+    ]);
+
+    const foo = runInInjectionContext(injector, () => inject(AbstractFoo));
+
+    expect(foo).toBeDefined();
+    expect(foo).toBeInstanceOf(Foo);
+  });
+  it('should support multi providers', () => {
+    class Foo {}
+
+    const { injector } = setup([
+      {
+        provide: Foo,
+        useClass: Foo,
+        multi: true,
+      },
+    ]);
+
+    const foo = runInInjectionContext(injector, () => inject<Foo[]>(Foo));
+
+    expect(foo.length).toBeGreaterThanOrEqual(1);
+    foo.forEach((foo) => expect(foo).toBeInstanceOf(Foo));
+  });
+
   it('should throw outside an injection context', () => {
     expect(() => inject(Bar)).toThrowError();
   });


### PR DESCRIPTION
- added `AbstractType` and `ProviderToken`
- added `InjectOptions` to `inject()`
- added optional support for `inject()`

fixes #68 